### PR TITLE
fix: app crashing during filtering | fixes #42

### DIFF
--- a/src/components/gallery/ShowcaseCard/index.tsx
+++ b/src/components/gallery/ShowcaseCard/index.tsx
@@ -1,12 +1,7 @@
 import React, { useEffect, useState } from "react";
 import styleCSS from "./styles.module.css";
 import { type User } from "../../../data/tags";
-import {
-  Card,
-  CardFooter,
-  Caption1Strong,
-  Image,
-} from "@fluentui/react-components";
+import { Card, CardFooter, Caption1Strong, Image } from "@fluentui/react-components";
 import { useBoolean } from "@fluentui/react-hooks";
 import { Panel, PanelType, ThemeProvider, PartialTheme } from "@fluentui/react";
 import ShowcaseCardPanel from "../ShowcaseCardPanel/index";
@@ -29,7 +24,6 @@ function ShowcaseCard({
   user: User;
   coverPage: Boolean;
 }): JSX.Element {
-
   const tags = user.tags;
   const title = user.title;
   const { colorMode } = useColorMode();
@@ -48,8 +42,7 @@ function ShowcaseCard({
     },
   };
 
-  const [isOpen, { setTrue: openPanel, setFalse: dismissPanel }] =
-    useBoolean(false);
+  const [isOpen, { setTrue: openPanel, setFalse: dismissPanel }] = useBoolean(false);
   const [githubData, setGithubData] = useState<GitHubRepoInfo>(null);
 
   const fetchGitHubData = async (owner: string, repo: string) => {
@@ -122,7 +115,9 @@ function ShowcaseCard({
         {coverPage ? (
           <>
             <div className={styleCSS.cardTitleCoverPage}>{title}</div>
-            <div className={styleCSS.cardDescriptionCoverPage}>{user.description}</div>
+            <div className={styleCSS.cardDescriptionCoverPage}>
+              {user.description}
+            </div>
           </>
         ) : (
           <>
@@ -162,7 +157,11 @@ const GitHubInfo = ({ githubData }) => {
         <>
           <Image
             alt="fork"
-            src={colorMode === "dark" ? useBaseUrl("/img/forkDark.svg") : useBaseUrl("/img/fork.svg")}
+            src={
+              colorMode === "dark"
+                ? useBaseUrl("/img/forkDark.svg")
+                : useBaseUrl("/img/fork.svg")
+            }
             height={16}
             width={16}
           />
@@ -175,7 +174,11 @@ const GitHubInfo = ({ githubData }) => {
         <>
           <Image
             alt="star"
-            src={colorMode === "dark" ? useBaseUrl("/img/starDark.svg") : useBaseUrl("/img/star.svg")}
+            src={
+              colorMode === "dark"
+                ? useBaseUrl("/img/starDark.svg")
+                : useBaseUrl("/img/star.svg")
+            }
             height={16}
             width={16}
           />

--- a/src/components/gallery/TagImage/index.tsx
+++ b/src/components/gallery/TagImage/index.tsx
@@ -1,0 +1,29 @@
+import React from "react";
+import { Tooltip, Image, Button } from "@fluentui/react-components";
+import useBaseUrl from "@docusaurus/useBaseUrl";
+import { useColorMode } from "@docusaurus/theme-common";
+
+export function TagImage({ tagObject }) {
+  const { colorMode } = useColorMode();
+
+  return (
+    <>
+      <Tooltip withArrow content={tagObject.label} relationship="label">
+        <Button
+          icon={
+            <Image
+              alt={tagObject.label}
+              src={useBaseUrl(
+                colorMode === "dark" && tagObject.darkIcon
+                  ? tagObject.darkIcon
+                  : tagObject.icon
+              )}
+              height={16}
+              width={16}
+            />
+          }
+        />
+      </Tooltip>
+    </>
+  );
+}


### PR DESCRIPTION
- Filter and map tags, avoiding redundant filtering for each type in ShowCaseIcon Component
- Created a new component for Tag Images.
- Memorized Tag values using `useMemo` to avoid unnecessary re-renders
- Adhere to [React Hooks Rules](https://react.dev/reference/rules/rules-of-hooks)

Fixes #42